### PR TITLE
Feature/enhanced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea/
 /node_modules/
 npm-debug.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
+<a name="0.6.2-enhanced"></a>
+## [0.6.2-enhanced](https://github.com/JamieMason/commit-release/compare/0.6.2...v0.6.2-enhanced) (2016-10-27)
+
+
+### Bug Fixes
+
+* **dont-tag:** update final message, fix tagging progress ([aeb8b63](https://github.com/JamieMason/commit-release/commit/aeb8b63))
+
+
+### Features
+
+* **bump:** use conventional-recommended-bump ([6ba3ed1](https://github.com/JamieMason/commit-release/commit/6ba3ed1))
+* **dont-tag:** add option -t (--no-tag) ([2e9513d](https://github.com/JamieMason/commit-release/commit/2e9513d))
+* **verbose:** add option -v (--verbose) ([9561426](https://github.com/JamieMason/commit-release/commit/9561426))
+
+
+
 <a name="0.6.2"></a>
-## [0.6.2](https://github.com/JamieMason/commit-release/compare/0.6.1...v0.6.2) (2016-07-26)
+## [0.6.2](https://github.com/JamieMason/commit-release/compare/0.6.1...0.6.2) (2016-07-26)
 
 
 ### Bug Fixes
@@ -25,6 +42,7 @@
 ### Bug Fixes
 
 * **shell:** use spawn instead of exec ([80f9d63](https://github.com/JamieMason/commit-release/commit/80f9d63)), closes [#1](https://github.com/JamieMason/commit-release/issues/1)
+
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
+<a name="0.6.3-enhanced"></a>
+## [0.6.3-enhanced](https://github.com/JamieMason/commit-release/compare/0.6.2-enhanced...v0.6.3-enhanced) (2016-12-07)
+
+
+### Bug Fixes
+
+* **verbose:** re-allow stdout ([cc68c7c](https://github.com/JamieMason/commit-release/commit/cc68c7c))
+
+
+
 <a name="0.6.2-enhanced"></a>
-## [0.6.2-enhanced](https://github.com/JamieMason/commit-release/compare/0.6.2...v0.6.2-enhanced) (2016-10-27)
+## [0.6.2-enhanced](https://github.com/JamieMason/commit-release/compare/0.6.2...0.6.2-enhanced) (2016-10-27)
 
 
 ### Bug Fixes

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -17,6 +17,7 @@ npm install commit-release --save
 - [chalk](https://github.com/chalk/chalk): Terminal string styling done right. Much color.
 - [commander](https://github.com/tj/commander.js): the complete solution for node.js command-line programs
 - [conventional-changelog](https://github.com/ajoslin/conventional-changelog): Generate a changelog from git metadata
+- [conventional-recommended-bump](https://github.com/conventional-changelog/conventional-recommended-bump): Get a recommended version bump based on conventional commits
 - [conventional-recommended-version](https://github.com/JamieMason/conventional-recommended-version): Using a conventional-changelog commit history, determine the current version number of your project.
 - [package-json-to-readme](https://github.com/zeke/package-json-to-readme): Generate a README.md from package.json contents
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ $ commit-release --help
   Options:
 
     -h, --help                output usage information
+    -b, --bump                use "conventional-recommended-bump"
     -f, --force               overwrite tag if it exists already
     -n, --no-verify           skip git commit hooks
     -o, --override [version]  override recommended version number
     -p, --postfix [name]      a postfix such as "rc1", "canary" or "beta1"
+    -t, --no-tag              does not automatically tag the commit
+    -v, --verbose             let the shell commands be more talkative
 ```

--- a/index.js
+++ b/index.js
@@ -33,5 +33,8 @@ function onComplete (err, options) {
     process.exit(1);
   }
 
-  console.log(chalk.green('Release ' + options.version + ' committed and tagged, changelog updated.'));
+  console.log(chalk.green(
+    'Release ' + options.version + ' committed' +
+    (!options.noTag ? ' and tagged' : '') +
+    ', changelog updated.'));
 }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var commitRelease = require('./src/commitRelease');
 
 // implementation
 program
+  .option('-b, --bump', 'use "conventional-recommended-bump"')
   .option('-f, --force', 'overwrite tag if it exists already')
   .option('-n, --no-verify', 'skip git commit hooks')
   .option('-o, --override [version]', 'override recommended version number', '')
@@ -19,6 +20,7 @@ program
 
 commitRelease.create({
   directory: process.cwd(),
+  bump: program.bump,
   force: program.force,
   noVerify: !program.verify,
   overrideVersion: program.override,

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ program
   .option('-o, --override [version]', 'override recommended version number', '')
   .option('-p, --postfix [name]', 'a postfix such as "rc1", "canary" or "beta1"', '')
   .option('-t, --no-tag', 'does not automatically tag the commit')
+  .option('-v, --verbose', 'let the shell commands be more talkative')
   .parse(process.argv);
 
 commitRelease.create({
@@ -23,6 +24,7 @@ commitRelease.create({
   overrideVersion: program.override,
   postfix: program.postfix,
   noTag: !program.tag,
+  verbose: program.verbose
 }, onComplete);
 
 function onComplete (err, options) {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ program
   .option('-n, --no-verify', 'skip git commit hooks')
   .option('-o, --override [version]', 'override recommended version number', '')
   .option('-p, --postfix [name]', 'a postfix such as "rc1", "canary" or "beta1"', '')
+  .option('-t, --no-tag', 'does not automatically tag the commit')
   .parse(process.argv);
 
 commitRelease.create({
@@ -20,7 +21,8 @@ commitRelease.create({
   force: program.force,
   noVerify: !program.verify,
   overrideVersion: program.override,
-  postfix: program.postfix
+  postfix: program.postfix,
+  noTag: !program.tag,
 }, onComplete);
 
 function onComplete (err, options) {
@@ -28,5 +30,6 @@ function onComplete (err, options) {
     console.error(chalk.red(err.stack ? err.stack : err));
     process.exit(1);
   }
+
   console.log(chalk.green('Release ' + options.version + ' committed and tagged, changelog updated.'));
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "chalk": "1.1.3",
     "commander": "2.9.0",
     "conventional-changelog": "1.1.0",
+    "conventional-recommended-bump": "0.3.0",
     "conventional-recommended-version": "0.3.2",
     "package-json-to-readme": "1.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-release",
   "description": "Commit and tag a release for a conventional changelog project.",
-  "version": "0.6.2",
+  "version": "0.6.2-enhanced",
   "author": "Jamie Mason (https://github.com/JamieMason)",
   "bin": {
     "commit-release": "./index.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commit-release",
   "description": "Commit and tag a release for a conventional changelog project.",
-  "version": "0.6.2-enhanced",
+  "version": "0.6.3-enhanced",
   "author": "Jamie Mason (https://github.com/JamieMason)",
   "bin": {
     "commit-release": "./index.js"

--- a/src/bump.js
+++ b/src/bump.js
@@ -1,0 +1,84 @@
+// modules
+var bump = require('conventional-recommended-bump');
+
+// public
+module.exports = {
+  get: get
+};
+
+// implementation
+function get (options, done) {
+  var currentVersion = getCurrentVersion();
+  var postfix = getPostfix();
+
+  checkBump()
+    .then(bumpVersion)
+    .then(onSuccess, onError)
+    .catch(onError);
+
+  function onSuccess (version) {
+    done(null, version);
+  }
+
+  function onError (message) {
+    done(message);
+  }
+
+  function bumpVersion (result) {
+    var v = { major: 0, minor: 0, patch: 0 };
+
+    switch (result.releaseType) {
+      case 'major':
+        v.major = currentVersion.major + 1;
+        break;
+      case 'minor':
+        v.major = currentVersion.major;
+        v.minor = currentVersion.minor + 1;
+        break;
+      case 'patch':
+      default:
+        v.major = currentVersion.major;
+        v.minor = currentVersion.minor;
+        v.patch = currentVersion.patch + 1;
+    }
+
+    return [v.major, v.minor, v.patch].join('.') + postfix;
+  }
+
+  function checkBump () {
+    return new Promise(function (resolve, reject) {
+      bump({
+        preset: 'angular'
+      }, function (err, result) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  }
+
+  function getCurrentVersion () {
+    var levels = ['major', 'minor', 'patch', 'postfix'];
+
+    return require(options.directory + '/package.json')
+      .version
+      .split('.')
+      .reduce(function (obj, num, i) {
+        if (i === 2) {
+          num = num.split('-');
+          obj[levels[i + 1]] = num[1] || '';
+          num = num[0];
+        }
+
+        obj[levels[i]] = parseInt(num);
+
+        return obj;
+      }, {});
+  }
+
+  function getPostfix () {
+    return options.postfix ? '-' + options.postfix : '';
+  }
+}

--- a/src/commitRelease.js
+++ b/src/commitRelease.js
@@ -43,14 +43,21 @@ function checkTagExists (options) {
 }
 
 function createCommit (options) {
+  // variables
   var logPath = path.resolve(options.directory, 'CHANGELOG.md');
+  var force = options.force ? '--force' : '';
+  var message = 'chore(release): ' + options.version;
+  var verify = options.noVerify ? '--no-verify' : '';
+
+  // actions
   var bump = exec.shell.bind(null, 'npm', ['version', options.version, '--no-git-tag-version', '--force']);
   var clearLog = exec.shell.bind(null, 'rm', ['-f', logPath]);
   var writeLog = updateChangeLog.bind(null, options);
   var writeDependencies = updateDepsLog.bind(null, options.directory);
   var stage = exec.shell.bind(null, 'git', ['add', '.', '-A']);
-  var commit = exec.shell.bind(null, 'git', ['commit', '-m', 'chore(release): ' + options.version, options.noVerify ? '--no-verify' : '']);
-  var tag = exec.shell.bind(null, 'git', ['tag', options.version, options.force ? '--force' : '']);
+  var commit = exec.shell.bind(null, 'git', ['commit', '-m', message, verify]);
+  var doTag = exec.shell.bind(null, 'git', ['tag', options.version, force]);
+  var tag = !options.noTag ? doTag() : options;
 
   return checkVersion(options)
     .then(bump)
@@ -70,7 +77,7 @@ function checkVersion (options) {
       var error = new Error('Current version is already ' + options.version);
       reject(error);
     } else {
-      resolve(options.version);
+      resolve(options);
     }
   });
 }

--- a/src/commitRelease.js
+++ b/src/commitRelease.js
@@ -57,7 +57,7 @@ function createCommit (options) {
   var stage = exec.shell.bind(null, 'git', ['add', '.', '-A'], options.verbose);
   var commit = exec.shell.bind(null, 'git', ['commit', '-m', message, verify], options.verbose);
   var doTag = exec.shell.bind(null, 'git', ['tag', options.version, force], options.verbose);
-  var tag = !options.noTag ? doTag() : options;
+  var tag = !options.noTag ? doTag : function () {};
 
   return checkVersion(options)
     .then(bump)

--- a/src/commitRelease.js
+++ b/src/commitRelease.js
@@ -1,6 +1,5 @@
 // 3rd party modules
 var changelog = require('conventional-changelog');
-var crv = require('conventional-recommended-version');
 var fs = require('fs');
 var path = require('path');
 
@@ -113,7 +112,9 @@ function getVersion (options) {
     return Promise.resolve(options);
   }
   return new Promise(function (resolve, reject) {
-    crv.get(options, function (err, version) {
+    var method = options.bump ? './bump' : 'conventional-recommended-version';
+    var cr = require(method);
+    cr.get(options, function (err, version) {
       if (err) {
         reject(err);
       } else {

--- a/src/exec.js
+++ b/src/exec.js
@@ -8,7 +8,7 @@ module.exports = {
 };
 
 // implementation
-function execShell (program, args) {
+function execShell (program, args, verbose) {
   return new Promise(function (resolve, reject) {
     var truthyArgs = args.filter(isTruthy);
     var proc = childProcess.spawn(program, truthyArgs);
@@ -21,8 +21,8 @@ function execShell (program, args) {
     proc.on('close', onClose);
 
     function onStdout (data) {
-      console.log(template, data);
-      stdout += data;
+      console.log(template, tell(data));
+      stdout += tell(data);
     }
 
     function onStderr (data) {
@@ -36,6 +36,10 @@ function execShell (program, args) {
       } else {
         resolve(stdout);
       }
+    }
+
+    function tell(data) {
+      return verbose ? data : '';
     }
   });
 }

--- a/src/exec.js
+++ b/src/exec.js
@@ -22,7 +22,7 @@ function execShell (program, args, verbose) {
 
     function onStdout (data) {
       console.log(template, tell(data));
-      stdout += tell(data);
+      stdout += data;
     }
 
     function onStderr (data) {


### PR DESCRIPTION
Added some helpful options:

`-t, --no-tag`  - omits to tag the commit. This is very useful if you run some other scripts in one pipe with `commit-release`. You can then tag your commit manually at the end.

`-v, --verbose` - I've hidden all `stdout` messages from shell commands, which enhanced readability of (i.e. shortens) the ongoing process. This option allows to display them back.

`-b, --bump` - uses the `conventional-recommended-bump` in place of `conventional-recommended-version`
